### PR TITLE
added types filtering to the frontend

### DIFF
--- a/src/client/src/Domains/Jobs/JobSearchForm/index.tsx
+++ b/src/client/src/Domains/Jobs/JobSearchForm/index.tsx
@@ -123,7 +123,6 @@ function JobSearchForm({ setJobs, children }: props) {
                                     <Field
                                         name='type'
                                         label='Type'
-                                        //component={TextFormField}
                                         options={jobTypes}
                                         multiple
                                         component={SelectFormField}

--- a/src/client/src/Domains/Jobs/JobSearchForm/index.tsx
+++ b/src/client/src/Domains/Jobs/JobSearchForm/index.tsx
@@ -10,8 +10,9 @@ import useApi from 'hooks/useApi';
 import useSnack from 'hooks/useSnack';
 import Loader from 'Components/Loader';
 import { TextFormField } from 'Components/TextFormField';
-import { getJobs, IJob } from 'Domains/Jobs/api/api';
+import { getJobs, IJob, jobTypes } from 'Domains/Jobs/api/api';
 import { Pagination } from '@material-ui/lab';
+import { SelectFormField } from 'Components/SelectFormField';
 
 interface props {
     setJobs: (jobs: IJob[]) => void;
@@ -20,18 +21,22 @@ interface props {
 
 interface JobSearchFormType {
     title: string;
+    type: string[];
     minSalary: string;
     hoursPerWeek: string;
 }
 
 const formInitialValues = {
     title: '',
+    type: [],
     minSalary: '',
     hoursPerWeek: '',
 };
 
 const formSchema = yup.object({
     title: yup.string().required(),
+    //title: yup.string().optional(),
+    type: yup.string().optional(),
     minSalary: yup.number().min(0).optional(),
     hoursPerWeek: yup.number().moreThan(0).optional(),
 });
@@ -48,6 +53,7 @@ function JobSearchForm({ setJobs, children }: props) {
         () =>
             getJobs(
                 formState.title,
+                formState.type,
                 formState.minSalary,
                 formState.hoursPerWeek,
                 page,
@@ -113,7 +119,16 @@ function JobSearchForm({ setJobs, children }: props) {
                                         component={TextFormField}
                                     />
                                 </Grid>
-
+                                <Grid item md={3} xs={12} >
+                                    <Field
+                                        name='type'
+                                        label='Type'
+                                        //component={TextFormField}
+                                        options={jobTypes}
+                                        multiple
+                                        component={SelectFormField}
+                                    />
+                                </Grid>
                                 <Grid item md={2} xs={12}>
                                     <Field
                                         name='minSalary'

--- a/src/client/src/Domains/Jobs/api/api.ts
+++ b/src/client/src/Domains/Jobs/api/api.ts
@@ -84,6 +84,7 @@ export interface IJob {
 
 export async function getJobs(
     title: string,
+    type: string[],
     minSalary: string,
     hoursPerWeek: string,
     page: number,
@@ -91,6 +92,7 @@ export async function getJobs(
 ) {
     const params = {
         title,
+        type,
         minSalary,
         hoursPerWeek,
         page,

--- a/src/server/src/modules/job.ts
+++ b/src/server/src/modules/job.ts
@@ -138,7 +138,6 @@ export const getJobs = async (
             title: `%${title.toLowerCase()}%`,
         })
         .orWhere('job.type IN (:...types)', { types })
-        //.orWhere('ARRAY[job.type] = ARRAY[:types]', { types: types})
         .orWhere('job.type LIKE :type', { type: `%${modType}%`})
         .orWhere('job.minSalary >= :minSalary', { minSalary })
         .orWhere('job.hoursPerWeek >= :hoursPerWeek', { hoursPerWeek })

--- a/src/server/src/modules/job.ts
+++ b/src/server/src/modules/job.ts
@@ -119,6 +119,10 @@ export const getJobs = async (
     page: number,
     numOfItems: number
 ) => {
+    let modType = '';
+    if (types) {
+        modType = types.join(',');
+    }
     return await getRepository(Job)
         .createQueryBuilder('job')
         .select([
@@ -134,6 +138,8 @@ export const getJobs = async (
             title: `%${title.toLowerCase()}%`,
         })
         .orWhere('job.type IN (:...types)', { types })
+        //.orWhere('ARRAY[job.type] = ARRAY[:types]', { types: types})
+        .orWhere('job.type LIKE :type', { type: `%${modType}%`})
         .orWhere('job.minSalary >= :minSalary', { minSalary })
         .orWhere('job.hoursPerWeek >= :hoursPerWeek', { hoursPerWeek })
         .skip((page - 1) * numOfItems)

--- a/src/server/src/routes/job.ts
+++ b/src/server/src/routes/job.ts
@@ -131,7 +131,7 @@ router.get(
 
         try {
             if (!title) {
-                title = 'laskjhagh';
+                title = '';
             }
             if (!minSalary) {
                 minSalary = '10000';

--- a/src/server/src/routes/job.ts
+++ b/src/server/src/routes/job.ts
@@ -121,7 +121,7 @@ router.get(
             numOfItems,
         } = req.query as {
             title: string;
-            type: string;
+            type: string[];
             startDate: string;
             minSalary: string;
             hoursPerWeek: string;
@@ -130,9 +130,8 @@ router.get(
         };
 
         try {
-            let types: string[] = [''];
             if (!title) {
-                title = '';
+                title = 'laskjhagh';
             }
             if (!minSalary) {
                 minSalary = '10000';
@@ -143,12 +142,9 @@ router.get(
             if (!startDate) {
                 startDate = '01/01/3000';
             }
-            if (type) {
-                types = type.split(',');
-            }
             const [jobs, jobsCount] = await getJobs(
                 title,
-                types,
+                type,
                 startDate,
                 parseInt(minSalary),
                 parseInt(hoursPerWeek),


### PR DESCRIPTION
Filtering by job type is added to the frontend.

Problem before:
Let's say we have 3 jobs in the database:
1. Job1 type = ['grader']
2. Job2 type = ['assistnat']
3. Job3 type = ['grader', 'assistant']
Our problem before was that if we were to filter by type = ['grader', assistant'], the system will only return 2 jobs: one with 'grader' as its type and another with 'assistant' as its type.

Now:
I managed to figure out why it was doing that and fixed it. The system will now return the 3 jobs listed above.