### PR TITLE
Get messages pagination

### DIFF
--- a/src/client/src/Domains/Messages/GetMessages/index.tsx
+++ b/src/client/src/Domains/Messages/GetMessages/index.tsx
@@ -15,7 +15,8 @@ interface MessagesProps {
 function Messages({ receiver }: MessagesProps) {
     const [messages, setMessages] = React.useState<IMessage[]>([]);
     const { user } = React.useContext(AuthContext);
-    const request = React.useCallback(() => getMessages(receiver), [receiver]);
+    // TODO: Update parameter of getMessages().
+    const request = React.useCallback(() => getMessages(100, receiver), [receiver]);
     const [sendRequest, isLoading] = useApi(request, {
         onSuccess: (response) => {
             setMessages(response.data.messages);

--- a/src/client/src/Domains/Messages/api/index.tsx
+++ b/src/client/src/Domains/Messages/api/index.tsx
@@ -23,9 +23,14 @@ export async function sendMessage(message: IMessageSendForm, receiver?: IUser) {
     });
 }
 
-export async function getMessages(messenger?: IUser) {
-    return API.get<{ messages: IMessage[] }>(
-        `message/getMessages/${messenger?.id}`
+export async function getMessages(page: number, messanger?: IUser) {
+    const params = {
+        messangerId: messanger?.id,
+        page,
+    };
+    return API.get<{ messages: IMessage[]; messagesCount: number }>(
+        `message/getMessages`,
+        { params }
     );
 }
 

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1017,15 +1017,20 @@ Messaging API
             -   errors:
                 -   Internal server error -> Status code: 500
 
-    -   api/message/getMessages/:messengerId
+    -   api/message/getMessages
 
-        -   Gets all messages between the logged-in user and the user with the parameter id, sorted from the oldest to the newest.
+        -   Gets top [20 * page] newest messages between the logged-in user and the user with messengerId, sorted from the oldest to the newest.
         -   Authorization restrictions:
             -   User must be logged in
         -   Body: None
-        -   Parameters: id of the messenger.
+        -   Parameters:
+            ```
+            {
+                messangerId: string;
+                page: string;
+            };
+            ```
         -   Response:
-
             -   success:
                 Status code: 200
 
@@ -1052,7 +1057,8 @@ Messaging API
                                 lastName: string,
                                 middleName?: string
                             }
-                        }[]
+                        }[],
+                        messagesCount: number
                     }
 
             -   errors:

--- a/src/server/src/routes/message/schemas.ts
+++ b/src/server/src/routes/message/schemas.ts
@@ -4,3 +4,8 @@ export const sendMessageSchema = Joi.object({
     content: Joi.string().required(),
     receiverId: Joi.number().required()
 });
+
+export const getMessagesSchema = Joi.object({
+    messangerId: Joi.string().required(),
+    page: Joi.string().required(),
+});


### PR DESCRIPTION
Modify GetMessages API so that it returns [page * 20] newest messages.
(Initially, the query returns the top 20 newest messages. When the user can press "Load more", the backend API returns the top 40 newest messages.)